### PR TITLE
Aggregate Performance and Syntax Cleanup

### DIFF
--- a/bounty_board/mongo/bdao_north_star_metrics.js
+++ b/bounty_board/mongo/bdao_north_star_metrics.js
@@ -8,7 +8,12 @@
 
 // Example Bounties Created
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 1 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -18,8 +23,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -30,19 +35,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 1 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Example Bounties Claimed
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      claimedAt: { $gt: Date(new Date() - 1 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -52,8 +57,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -64,14 +69,9 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      claimedAt: { $gt: new Date(new Date() - 1 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // ---------- Weekly Active Users-----------------
@@ -80,7 +80,12 @@ db.bounties.aggregate([
 
 // Example Bounties Submitted
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      submittedAt: { $gt: Date(new Date() - 7 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -90,8 +95,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -102,19 +107,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      submittedAt: { $gt: new Date(new Date() - 7 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Example Bounties Reviewed
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      reviewedAt: { $gt: Date(new Date() - 7 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -124,8 +129,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -136,14 +141,9 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      reviewedAt: { $gt: new Date(new Date() - 7 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // ---------- Monthly Active Users-----------------
@@ -152,7 +152,12 @@ db.bounties.aggregate([
 
 // Example Bounties Created
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    }
+  },
   {
     $project: {
       _id: 1,
@@ -162,8 +167,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -174,14 +179,9 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // ---------- UNIQUE USERS ------------
@@ -192,7 +192,12 @@ db.bounties.aggregate([
 
 // Example Number of Unique Creators (by week, past 30-days)
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -200,8 +205,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _createdAt: "$createdAt",
-      "createdBy.discordHandle": 1,
-    },
+      "createdBy.discordHandle": 1
+    }
   },
   {
     $project: {
@@ -210,26 +215,26 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       createdAt: { $toDate: "$_createdAt" },
-      "createdBy.discordHandle": 1,
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
+      "createdBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$createdAt" } },
       num_creators: { $sum: 1 },
       unique_creators: { $addToSet: "$createdBy.discordHandle" },
-    },
-  },
+    }
+  }
 ]);
 
 // Example Number of Unique Reviewers (by week, past 30-days)
 db.bounties.aggregate([
-  { $match: { customerId: "834499078434979890" } },
+  { 
+    $match: { 
+      customerId: "834499078434979890",
+      reviewedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    }
+  },
   {
     $project: {
       _id: 1,
@@ -237,8 +242,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _reviewedAt: "$reviewedAt",
-      "reviewedBy.discordHandle": 1,
-    },
+      "reviewedBy.discordHandle": 1
+    }
   },
   {
     $project: {
@@ -247,21 +252,16 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       reviewedAt: { $toDate: "$_reviewedAt" },
-      "reviewedBy.discordHandle": 1,
-    },
-  },
-  {
-    $match: {
-      reviewedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
+      "reviewedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$reviewedAt" } },
       num_reviewers: { $sum: 1 },
-      unique_reviewers: { $addToSet: "$reviewedBy.discordHandle" },
-    },
-  },
+      unique_reviewers: { $addToSet: "$reviewedBy.discordHandle" }
+    }
+  }
 ]);
 
 // -----------Unique Weekly Active Users (since Jan 1st 2022) ------------
@@ -274,23 +274,23 @@ db.bounties.aggregate([
     $match: {
       $and: [
         { customerId: "834499078434979890" },
-        { claimedAt: { $gte: "2022-01-01" } },
-      ],
-    },
+        { claimedAt: { $gte: "2022-01-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       claimedAt: { $toDate: "$claimedAt" },
-      "claimedBy.discordHandle": 1,
-    },
+      "claimedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$claimedAt" } },
-      unique_claimers: { $addToSet: "$claimedBy.discordHandle" },
-    },
-  },
+      unique_claimers: { $addToSet: "$claimedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Example Number of Unique Submitters (since Jan 1st 2022)
@@ -299,23 +299,23 @@ db.bounties.aggregate([
     $match: {
       $and: [
         { customerId: "834499078434979890" },
-        { submittedAt: { $gte: "2022-01-01" } },
-      ],
-    },
+        { submittedAt: { $gte: "2022-01-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       submittedAt: { $toDate: "$submittedAt" },
-      "submittedBy.discordHandle": 1,
-    },
+      "submittedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$submittedAt" } },
-      unique_submitters: { $addToSet: "$submittedBy.discordHandle" },
-    },
-  },
+      unique_submitters: { $addToSet: "$submittedBy.discordHandle" }
+    }
+  }
 ]);
 
 // ---------------- Percentage of Bounties Created (since Jan 1st 2022) --------------
@@ -327,19 +327,19 @@ db.bounties.aggregate([
     $group: {
       _id: 1,
       count_new: {
-        $sum: { $cond: [{ $gte: ["$createdAt", "2022-01-01"] }, 1, 0] },
+        $sum: { $cond: [{ $gte: ["$createdAt", "2022-01-01"] }, 1, 0] }
       },
       count_repeat: {
-        $sum: { $cond: [{ $lt: ["$createdAt", "2022-01-01"] }, 1, 0] },
-      },
-    },
+        $sum: { $cond: [{ $lt: ["$createdAt", "2022-01-01"] }, 1, 0] }
+      }
+    }
   },
   {
     $project: {
       _id: 1,
-      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] },
-    },
-  },
+      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] }
+    }
+  }
 ]);
 
 // Percentage % Bounties Created since Feb 1st, 2022
@@ -349,17 +349,17 @@ db.bounties.aggregate([
     $group: {
       _id: 1,
       count_new: {
-        $sum: { $cond: [{ $gte: ["$createdAt", "2022-02-01"] }, 1, 0] },
+        $sum: { $cond: [{ $gte: ["$createdAt", "2022-02-01"] }, 1, 0] }
       },
       count_repeat: {
-        $sum: { $cond: [{ $lt: ["$createdAt", "2022-02-01"] }, 1, 0] },
-      },
-    },
+        $sum: { $cond: [{ $lt: ["$createdAt", "2022-02-01"] }, 1, 0] }
+      }
+    }
   },
   {
     $project: {
       _id: 1,
-      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] },
-    },
-  },
+      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] }
+    }
+  }
 ]);

--- a/bounty_board/mongo/indexes.js
+++ b/bounty_board/mongo/indexes.js
@@ -1,0 +1,9 @@
+db.bounties.createIndex(
+  {
+    customerId: 1,
+    createdAt: 1
+  },
+  {
+    background: true
+  }
+);

--- a/bounty_board/mongo/new_bounty_queries.js
+++ b/bounty_board/mongo/new_bounty_queries.js
@@ -2,7 +2,12 @@
 
 // Number of Bounties created in past 7-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 7 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -12,8 +17,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -24,19 +29,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 7 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Number of Bounties Claimed in past 7-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      claimedAt: { $gt: Date(new Date() - 7 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -46,8 +51,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -58,19 +63,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      claimedAt: { $gt: new Date(new Date() - 7 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Number of Bounties Submitted in past 7-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      submittedAt: { $gt: Date(new Date() - 7 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -80,8 +85,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -92,19 +97,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      submittedAt: { $gt: new Date(new Date() - 7 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Number of Bounties Reviewed in past 7-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      reviewedAt: { $gt: Date(new Date() - 7 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -114,8 +119,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -126,21 +131,21 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      reviewedAt: { $gt: new Date(new Date() - 7 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Monthly Active Users (past 30-days)
 
 //Number of Bounties created in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -150,8 +155,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -162,19 +167,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Number of Bounties claimed in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      claimedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -184,8 +189,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -196,19 +201,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      claimedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Number of Bounties Submitted in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      submittedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -218,8 +223,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -230,19 +235,19 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      submittedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // Number of Bounties Reviewed in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      reviewedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -252,8 +257,8 @@ db.bounties.aggregate([
       _createdAt: "$createdAt",
       _claimedAt: "$claimedAt",
       _submittedAt: "$submittedAt",
-      _reviewedAt: "$reviewedAt",
-    },
+      _reviewedAt: "$reviewedAt"
+    }
   },
   {
     $project: {
@@ -264,21 +269,21 @@ db.bounties.aggregate([
       createdAt: { $toDate: "$_createdAt" },
       claimedAt: { $toDate: "$_claimedAt" },
       submittedAt: { $toDate: "$_submittedAt" },
-      reviewedAt: { $toDate: "$_reviewedAt" },
-    },
-  },
-  {
-    $match: {
-      reviewedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      reviewedAt: { $toDate: "$_reviewedAt" }
+    }
+  }
 ]);
 
 // POWER USERS: Number of People who created, claimed, submitted, reviewed bounties in past 30-days
 
 //People who Created bounties in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    }
+  },
   {
     $project: {
       _id: 1,
@@ -286,8 +291,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _createdAt: "$createdAt",
-      _name: "$createdBy.discordHandle",
-    },
+      _name: "$createdBy.discordHandle"
+    }
   },
   {
     $project: {
@@ -296,19 +301,19 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       createdAt: { $toDate: "$_createdAt" },
-      name: "$_name",
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      name: "$_name"
+    }
+  }
 ]);
 
 //People who Claimed bounties in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      claimedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -316,8 +321,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _claimedAt: "$claimedAt",
-      _name: "$claimedBy.discordHandle",
-    },
+      _name: "$claimedBy.discordHandle"
+    }
   },
   {
     $project: {
@@ -326,19 +331,19 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       claimedAt: { $toDate: "$_claimedAt" },
-      name: "$_name",
-    },
-  },
-  {
-    $match: {
-      claimedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      name: "$_name"
+    }
+  }
 ]);
 
 //name of people who submitted bounties in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      submittedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -346,8 +351,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _submittedAt: "$submittedAt",
-      _name: "$submittedBy.discordHandle",
-    },
+      _name: "$submittedBy.discordHandle"
+    }
   },
   {
     $project: {
@@ -356,19 +361,19 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       submittedAt: { $toDate: "$_submittedAt" },
-      name: "$_name",
-    },
-  },
-  {
-    $match: {
-      submittedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      name: "$_name"
+    }
+  }
 ]);
 
 //name of people who reviewed bounties in past 30-days
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      reviewedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -376,8 +381,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _reviewedAt: "$reviewedAt",
-      _name: "$reviewedBy.discordHandle",
-    },
+      _name: "$reviewedBy.discordHandle"
+    }
   },
   {
     $project: {
@@ -386,14 +391,9 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       reviewedAt: { $toDate: "$_reviewedAt" },
-      name: "$_name",
-    },
-  },
-  {
-    $match: {
-      reviewedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
-  },
+      name: "$_name"
+    }
+  }
 ]);
 
 // IN-PROGRESS Bounties (valued locked)
@@ -406,26 +406,26 @@ db.bounties.aggregate([
         { customer_id: "834499078434979890" },
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { status: "In-Progress" },
-      ],
-    },
+        { status: "In-Progress" }
+      ]
+    }
   },
   {
     $project: {
       _id: 0,
       _title: "$title",
       _status: "$status",
-      _createdAt: "$createdAt",
-    },
+      _createdAt: "$createdAt"
+    }
   },
   {
     $project: {
       _id: 0,
       title: "$_title",
       status: "$_status",
-      createdAt: { $toDate: "$_createdAt" },
-    },
-  },
+      createdAt: { $toDate: "$_createdAt" }
+    }
+  }
 ]);
 
 // IN-REVIEW Bounties (value locked)
@@ -437,26 +437,26 @@ db.bounties.aggregate([
         { customer_id: "834499078434979890" },
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { status: "In-Review" },
-      ],
-    },
+        { status: "In-Review" }
+      ]
+    }
   },
   {
     $project: {
       _id: 0,
       _title: "$title",
       _status: "$status",
-      _createdAt: "$createdAt",
-    },
+      _createdAt: "$createdAt"
+    }
   },
   {
     $project: {
       _id: 0,
       title: "$_title",
       status: "$_status",
-      createdAt: { $toDate: "$_createdAt" },
-    },
-  },
+      createdAt: { $toDate: "$_createdAt" }
+    }
+  }
 ]);
 
 // Bounty Status (by Count)
@@ -467,9 +467,9 @@ db.bounties.aggregate([
       $and: [
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { customer_id: "834499078434979890" },
-      ],
-    },
+        { customer_id: "834499078434979890" }
+      ]
+    }
   },
   {
     $project: {
@@ -477,10 +477,10 @@ db.bounties.aggregate([
       customer_id: 1,
       "reward.amount": 1,
       "reward.currency": 1,
-      status: 1,
-    },
+      status: 1
+    }
   },
-  { $group: { _id: "$status", num_bounties: { $sum: 1 } } },
+  { $group: { _id: "$status", num_bounties: { $sum: 1 } } }
 ]);
 
 // Bounty Status (by Value)
@@ -491,9 +491,9 @@ db.bounties.aggregate([
       $and: [
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { customer_id: "834499078434979890" },
-      ],
-    },
+        { customer_id: "834499078434979890" }
+      ]
+    }
   },
   {
     $project: {
@@ -501,10 +501,10 @@ db.bounties.aggregate([
       customer_id: 1,
       "reward.amount": 1,
       "reward.currency": 1,
-      status: 1,
+      status: 1
     },
   },
-  { $group: { _id: "$status", sum: { $sum: "$reward.amount" } } },
+  { $group: { _id: "$status", sum: { $sum: "$reward.amount" } } }
 ]);
 
 // Total BANK Claimed from Completed Bounties
@@ -516,9 +516,9 @@ db.bounties.aggregate([
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
         { customer_id: "834499078434979890" },
-        { status: "Completed" },
-      ],
-    },
+        { status: "Completed" }
+      ]
+    }
   },
   {
     $project: {
@@ -526,10 +526,10 @@ db.bounties.aggregate([
       customer_id: 1,
       "reward.amount": 1,
       "reward.currency": 1,
-      status: 1,
-    },
+      status: 1
+    }
   },
-  { $group: { _id: "$customer_id", sum: { $sum: "$reward.amount" } } },
+  { $group: { _id: "$customer_id", sum: { $sum: "$reward.amount" } } }
 ]);
 
 // Total BANK Allocated for Bounties
@@ -540,9 +540,9 @@ db.bounties.aggregate([
       $and: [
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { customer_id: "834499078434979890" },
-      ],
-    },
+        { customer_id: "834499078434979890" }
+      ]
+    }
   },
   {
     $project: {
@@ -550,10 +550,10 @@ db.bounties.aggregate([
       customer_id: 1,
       "reward.amount": 1,
       "reward.currency": 1,
-      status: 1,
-    },
+      status: 1
+    }
   },
-  { $group: { _id: "$customer_id", sum: { $sum: "$reward.amount" } } },
+  { $group: { _id: "$customer_id", sum: { $sum: "$reward.amount" } } }
 ]);
 
 // Number of Bounties per week
@@ -564,18 +564,18 @@ db.bounties.aggregate([
       $and: [
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { customer_id: "834499078434979890" },
-      ],
-    },
+        { customer_id: "834499078434979890" }
+      ]
+    }
   },
   { $project: { _id: 1, season: 1, createdAt: { $toDate: "$createdAt" } } },
   {
     $group: {
       _id: { week: { $isoWeek: "$createdAt" } },
-      num_bounties: { $sum: 1 },
-    },
+      num_bounties: { $sum: 1 }
+    }
   },
-  { $sort: { week: -1 } },
+  { $sort: { week: -1 } }
 ]);
 
 // Amount of BANK committed per week
@@ -586,23 +586,23 @@ db.bounties.aggregate([
       $and: [
         { createdAt: { $gte: "2021-10-08" } },
         { createdAt: { $lte: "2022-01-08" } },
-        { "reward.currency": "BANK" },
-      ],
-    },
+        { "reward.currency": "BANK" }
+      ]
+    }
   },
   {
     $project: {
       _id: 0,
       season: 1,
       "reward.amount": 1,
-      createdAt: { $toDate: "$createdAt" },
-    },
+      createdAt: { $toDate: "$createdAt" }
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$createdAt" } },
-      total_reward: { $sum: "$reward.amount" },
-    },
+      total_reward: { $sum: "$reward.amount" }
+    }
   },
-  { $sort: { week: -1 } },
+  { $sort: { week: -1 } }
 ]);

--- a/bounty_board/mongo/usage_growth_queries.js
+++ b/bounty_board/mongo/usage_growth_queries.js
@@ -6,24 +6,24 @@ db.bounties.aggregate([
       $and: [
         { customer_id: "834499078434979890" },
         { createdAt: { $gte: "2022-01-01" } },
-        { createdAt: { $lt: "2022-02-01" } },
-      ],
-    },
+        { createdAt: { $lt: "2022-02-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       createdAt: { $toDate: "$createdAt" },
-      "createdBy.discordHandle": 1,
-    },
+      "createdBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$createdAt" } },
       num_creators: { $sum: 1 },
-      unique_creators: { $addToSet: "$createdBy.discordHandle" },
-    },
-  },
+      unique_creators: { $addToSet: "$createdBy.discordHandle" }
+    }
+  }
 ]);
 
 // Total and Unique Bounty Claimers by Week
@@ -34,24 +34,24 @@ db.bounties.aggregate([
       $and: [
         { customer_id: "834499078434979890" },
         { claimedAt: { $gte: "2022-01-01" } },
-        { claimedAt: { $lt: "2022-02-01" } },
-      ],
-    },
+        { claimedAt: { $lt: "2022-02-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       claimedAt: { $toDate: "$claimedAt" },
-      "claimedBy.discordHandle": 1,
-    },
+      "claimedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$claimedAt" } },
       num_claimers: { $sum: 1 },
-      unique_claimers: { $addToSet: "$claimedBy.discordHandle" },
-    },
-  },
+      unique_claimers: { $addToSet: "$claimedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Total and Unique Bounty Submitters by Week
@@ -62,24 +62,24 @@ db.bounties.aggregate([
       $and: [
         { customer_id: "834499078434979890" },
         { submittedAt: { $gte: "2022-01-01" } },
-        { submittedAt: { $lt: "2022-02-01" } },
-      ],
-    },
+        { submittedAt: { $lt: "2022-02-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       submittedAt: { $toDate: "$submittedAt" },
-      "submittedBy.discordHandle": 1,
-    },
+      "submittedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$submittedAt" } },
       num_submitters: { $sum: 1 },
-      unique_submitters: { $addToSet: "$submittedBy.discordHandle" },
-    },
-  },
+      unique_submitters: { $addToSet: "$submittedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Total and Unique Bounty Reviewers by Week
@@ -90,29 +90,34 @@ db.bounties.aggregate([
       $and: [
         { customer_id: "834499078434979890" },
         { reviewedAt: { $gte: "2022-01-01" } },
-        { reviewedAt: { $lt: "2022-02-01" } },
-      ],
-    },
+        { reviewedAt: { $lt: "2022-02-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       reviewedAt: { $toDate: "$reviewedAt" },
-      "reviewedBy.discordHandle": 1,
-    },
+      "reviewedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$reviewedAt" } },
       num_reviewers: { $sum: 1 },
-      unique_reviewer: { $addToSet: "$reviewedBy.discordHandle" },
-    },
-  },
+      unique_reviewer: { $addToSet: "$reviewedBy.discordHandle" }
+    }
+  }
 ]);
 
 // UNIQUE CREATORS - last 30 days (checked) FINAL
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      createdAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -120,8 +125,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _createdAt: "$createdAt",
-      "createdBy.discordHandle": 1,
-    },
+      "createdBy.discordHandle": 1
+    }
   },
   {
     $project: {
@@ -130,26 +135,26 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       createdAt: { $toDate: "$_createdAt" },
-      "createdBy.discordHandle": 1,
-    },
-  },
-  {
-    $match: {
-      createdAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
+      "createdBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$createdAt" } },
       num_creators: { $sum: 1 },
-      unique_creators: { $addToSet: "$createdBy.discordHandle" },
-    },
-  },
+      unique_creators: { $addToSet: "$createdBy.discordHandle" }
+    }
+  }
 ]);
 
 // UNIQUE CLAIMERS - last 30 days (checked) FINAL
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      claimedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -158,7 +163,7 @@ db.bounties.aggregate([
       _status: "$status",
       _claimedAt: "$claimedAt",
       "claimedBy.discordHandle": 1,
-    },
+    }
   },
   {
     $project: {
@@ -167,26 +172,26 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       claimedAt: { $toDate: "$_claimedAt" },
-      "claimedBy.discordHandle": 1,
-    },
-  },
-  {
-    $match: {
-      claimedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
+      "claimedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$claimedAt" } },
       num_claimers: { $sum: 1 },
-      unique_claimers: { $addToSet: "$claimedBy.discordHandle" },
-    },
-  },
+      unique_claimers: { $addToSet: "$claimedBy.discordHandle" }
+    }
+  }
 ]);
 
 // UNIQUE SUBMITTERS - last 30 days (checked) FINAL
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      submittedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    }
+  },
   {
     $project: {
       _id: 1,
@@ -194,8 +199,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _submittedAt: "$submittedAt",
-      "submittedBy.discordHandle": 1,
-    },
+      "submittedBy.discordHandle": 1
+    }
   },
   {
     $project: {
@@ -204,26 +209,26 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       submittedAt: { $toDate: "$_submittedAt" },
-      "submittedBy.discordHandle": 1,
-    },
-  },
-  {
-    $match: {
-      submittedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
+      "submittedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$submittedAt" } },
       num_submitters: { $sum: 1 },
-      unique_submitters: { $addToSet: "$submittedBy.discordHandle" },
-    },
-  },
+      unique_submitters: { $addToSet: "$submittedBy.discordHandle" }
+    }
+  }
 ]);
 
 // UNIQUE REVIEWERS - last 30 days (checked) FINAL
 db.bounties.aggregate([
-  { $match: { customer_id: "834499078434979890" } },
+  { 
+    $match: { 
+      customer_id: "834499078434979890",
+      reviewedAt: { $gt: Date(new Date() - 30 * 60 * 60 * 24 * 1000) }
+    } 
+  },
   {
     $project: {
       _id: 1,
@@ -231,8 +236,8 @@ db.bounties.aggregate([
       _title: "$title",
       _status: "$status",
       _reviewedAt: "$reviewedAt",
-      "reviewedBy.discordHandle": 1,
-    },
+      "reviewedBy.discordHandle": 1
+    }
   },
   {
     $project: {
@@ -241,21 +246,16 @@ db.bounties.aggregate([
       title: "$_title",
       status: "$_status",
       reviewedAt: { $toDate: "$_reviewedAt" },
-      "reviewedBy.discordHandle": 1,
-    },
-  },
-  {
-    $match: {
-      reviewedAt: { $gt: new Date(new Date() - 30 * 60 * 60 * 24 * 1000) },
-    },
+      "reviewedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$reviewedAt" } },
       num_reviewers: { $sum: 1 },
-      unique_reviewers: { $addToSet: "$reviewedBy.discordHandle" },
-    },
-  },
+      unique_reviewers: { $addToSet: "$reviewedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Number of (Unique) Bounty CREATORS per week since start of year (FINAL)
@@ -264,23 +264,23 @@ db.bounties.aggregate([
     $match: {
       $and: [
         { customer_id: "834499078434979890" },
-        { createdAt: { $gte: "2022-01-01" } },
-      ],
-    },
+        { createdAt: { $gte: "2022-01-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       createdAt: { $toDate: "$createdAt" },
-      "createdBy.discordHandle": 1,
-    },
+      "createdBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$createdAt" } },
-      unique_creators: { $addToSet: "$createdBy.discordHandle" },
-    },
-  },
+      unique_creators: { $addToSet: "$createdBy.discordHandle" }
+    }
+  }
 ]);
 
 // Number of (Unique) Bounty CLAIMERS per week since start of year (FINAL)
@@ -289,23 +289,23 @@ db.bounties.aggregate([
     $match: {
       $and: [
         { customer_id: "834499078434979890" },
-        { claimedAt: { $gte: "2022-01-01" } },
-      ],
-    },
+        { claimedAt: { $gte: "2022-01-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       claimedAt: { $toDate: "$claimedAt" },
-      "claimedBy.discordHandle": 1,
-    },
+      "claimedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$claimedAt" } },
-      unique_claimers: { $addToSet: "$claimedBy.discordHandle" },
-    },
-  },
+      unique_claimers: { $addToSet: "$claimedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Number of (Unique) Bounty SUBMITTERS per week since start of year (FINAL)
@@ -314,23 +314,23 @@ db.bounties.aggregate([
     $match: {
       $and: [
         { customer_id: "834499078434979890" },
-        { submittedAt: { $gte: "2022-01-01" } },
-      ],
-    },
+        { submittedAt: { $gte: "2022-01-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       submittedAt: { $toDate: "$submittedAt" },
-      "submittedBy.discordHandle": 1,
-    },
+      "submittedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$submittedAt" } },
-      unique_submitters: { $addToSet: "$submittedBy.discordHandle" },
-    },
-  },
+      unique_submitters: { $addToSet: "$submittedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Number of (Unique) Bounty REVIEWERS per week since start of year (FINAL)
@@ -339,23 +339,23 @@ db.bounties.aggregate([
     $match: {
       $and: [
         { customer_id: "834499078434979890" },
-        { reviewedAt: { $gte: "2022-01-01" } },
-      ],
-    },
+        { reviewedAt: { $gte: "2022-01-01" } }
+      ]
+    }
   },
   {
     $project: {
       _id: 1,
       reviewedAt: { $toDate: "$reviewedAt" },
-      "reviewedBy.discordHandle": 1,
-    },
+      "reviewedBy.discordHandle": 1
+    }
   },
   {
     $group: {
       _id: { week: { $isoWeek: "$reviewedAt" } },
-      unique_reviewers: { $addToSet: "$reviewedBy.discordHandle" },
-    },
-  },
+      unique_reviewers: { $addToSet: "$reviewedBy.discordHandle" }
+    }
+  }
 ]);
 
 // Find Query
@@ -367,8 +367,8 @@ db.bounties
   .find({
     $and: [
       { customer_id: "834499078434979890" },
-      { createdAt: { $lt: "2022-01-01" } },
-    ],
+      { createdAt: { $lt: "2022-01-01" } }
+    ]
   })
   .count();
 
@@ -377,8 +377,8 @@ db.bounties
   .find({
     $and: [
       { customer_id: "834499078434979890" },
-      { createdAt: { $gte: "2022-01-01" } },
-    ],
+      { createdAt: { $gte: "2022-01-01" } }
+    ]
   })
   .count();
 
@@ -387,8 +387,8 @@ db.bounties
   .find({
     $and: [
       { customer_id: "834499078434979890" },
-      { createdAt: { $gte: "2022-01-01", $lt: "2022-02-01" } },
-    ],
+      { createdAt: { $gte: "2022-01-01", $lt: "2022-02-01" } }
+    ]
   })
   .count();
 
@@ -401,19 +401,19 @@ db.bounties.aggregate([
     $group: {
       _id: 1,
       count_new: {
-        $sum: { $cond: [{ $gte: ["$createdAt", "2022-01-01"] }, 1, 0] },
+        $sum: { $cond: [{ $gte: ["$createdAt", "2022-01-01"] }, 1, 0] }
       },
       count_repeat: {
-        $sum: { $cond: [{ $lt: ["$createdAt", "2022-01-01"] }, 1, 0] },
-      },
-    },
+        $sum: { $cond: [{ $lt: ["$createdAt", "2022-01-01"] }, 1, 0] }
+      }
+    }
   },
   {
     $project: {
       _id: 1,
-      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] },
-    },
-  },
+      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] }
+    }
+  }
 ]);
 
 // Percentage of New Bounties created After Feb 1st 2022
@@ -424,17 +424,17 @@ db.bounties.aggregate([
     $group: {
       _id: 1,
       count_new: {
-        $sum: { $cond: [{ $gte: ["$createdAt", "2022-02-01"] }, 1, 0] },
+        $sum: { $cond: [{ $gte: ["$createdAt", "2022-02-01"] }, 1, 0] }
       },
       count_repeat: {
-        $sum: { $cond: [{ $lt: ["$createdAt", "2022-02-01"] }, 1, 0] },
-      },
-    },
+        $sum: { $cond: [{ $lt: ["$createdAt", "2022-02-01"] }, 1, 0] }
+      }
+    }
   },
   {
     $project: {
       _id: 1,
-      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] },
-    },
-  },
+      new_creator_percentage: { $divide: ["$count_new", "$count_repeat"] }
+    }
+  }
 ]);


### PR DESCRIPTION
MongoDB can range over string dates so by using `Date() (string)` in lieu of `new Date() (object)` we can move the range filter into the first match step, allowing the use of an index and improving performance. 

You can read more here from the official documentation [here](https://docs.mongodb.com/manual/reference/method/Date/) and [here](https://docs.mongodb.com/manual/core/aggregation-pipeline-optimization/)

**Benefits**
- In order for Aggregates to use an index, the match step must be the first step in the pipeline.
- No longer required to convert string type to date type.

Also cleaned up the excess comma's for better readability.